### PR TITLE
feat: add DuckDB cache for Wikipedia page links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 *.swp
 .env
 .venv/
+*.duckdb
+*.duckdb.wal
+app_run_logs.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "networkx>=2.5",
     "streamlit>=1.16.0",
     "streamlit-agraph>=0.0.45",
+    "duckdb>=0.9.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.28.0
 networkx>=2.5
 streamlit>=1.16.0
 streamlit-agraph>=0.0.45
+duckdb>=0.9.0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,62 @@
+import duckdb
+import pytest
+from wikiviz.cache import get_connection, get_cached_links, set_cached_links, get_cache_stats
+
+
+@pytest.fixture
+def cache_conn():
+    """Create an in-memory DuckDB cache for testing."""
+    conn = get_connection(":memory:")
+    yield conn
+    conn.close()
+
+
+def test_set_and_get_cached_links(cache_conn):
+    """Cached links should be retrievable after storing."""
+    links = ["Apple", "Banana", "Cherry"]
+    set_cached_links(cache_conn, "Fruit", links)
+
+    result = get_cached_links(cache_conn, "Fruit")
+
+    assert result == ["Apple", "Banana", "Cherry"]
+
+
+def test_get_cached_links_miss(cache_conn):
+    """Uncached pages should return None."""
+    result = get_cached_links(cache_conn, "Nonexistent")
+
+    assert result is None
+
+
+def test_cache_overwrites_on_update(cache_conn):
+    """Storing links for the same page should overwrite the old entry."""
+    set_cached_links(cache_conn, "Fruit", ["Apple"])
+    set_cached_links(cache_conn, "Fruit", ["Apple", "Banana"])
+
+    result = get_cached_links(cache_conn, "Fruit")
+
+    assert result == ["Apple", "Banana"]
+
+
+def test_get_cache_stats(cache_conn):
+    """Cache stats should reflect the number of cached pages."""
+    assert get_cache_stats(cache_conn)["total_pages"] == 0
+
+    set_cached_links(cache_conn, "Page1", ["A"])
+    set_cached_links(cache_conn, "Page2", ["B"])
+
+    assert get_cache_stats(cache_conn)["total_pages"] == 2
+
+
+def test_expired_cache_returns_none(cache_conn):
+    """Links older than TTL should not be returned."""
+    set_cached_links(cache_conn, "Old", ["A"])
+
+    # Manually backdate the fetched_at timestamp
+    cache_conn.execute(
+        "UPDATE link_cache SET fetched_at = '2020-01-01' WHERE page_title = 'Old'"
+    )
+
+    result = get_cached_links(cache_conn, "Old", ttl_days=7)
+
+    assert result is None

--- a/wikiviz/app.py
+++ b/wikiviz/app.py
@@ -5,9 +5,16 @@ from datetime import datetime
 import streamlit as st
 from streamlit_agraph import agraph, Node, Edge, Config
 
+from wikiviz.cache import get_connection, get_cache_stats
 from wikiviz.core import find_shortest_path
 
 st.set_page_config(page_title="wikiViz", page_icon=None, layout="wide")
+
+
+@st.cache_resource
+def _get_cache_conn():
+    """Get a shared DuckDB connection, cached across Streamlit reruns."""
+    return get_connection()
 
 
 def _wiki_url(title):
@@ -81,6 +88,11 @@ def _render_graph(path, graph):
 def main():
     st.title("Degrees of Separation: Wikipedia Edition")
 
+    # Sidebar: cache stats
+    cache_conn = _get_cache_conn()
+    stats = get_cache_stats(cache_conn)
+    st.sidebar.metric("Cached Pages", stats["total_pages"])
+
     st.write(
         "Give me any two Wikipedia pages and I'll tell you how many "
         "and what Wiki pages connect those two pages"
@@ -103,10 +115,14 @@ def main():
         def on_progress(count, title):
             status.text(f"Exploring page {count}: {title}...")
 
+        cache_conn = _get_cache_conn()
+
         try:
             with st.spinner("Searching for a path..."):
                 path, graph = find_shortest_path(
-                    search_node_a, search_node_b, on_progress=on_progress
+                    search_node_a, search_node_b,
+                    on_progress=on_progress,
+                    cache_conn=cache_conn,
                 )
             status.empty()
             degrees = len(path) - 1

--- a/wikiviz/cache.py
+++ b/wikiviz/cache.py
@@ -1,0 +1,57 @@
+"""DuckDB-backed cache for Wikipedia page links."""
+
+import json
+from datetime import datetime, timedelta
+
+import duckdb
+
+
+_DEFAULT_DB_PATH = "wikiviz_cache.duckdb"
+_DEFAULT_TTL_DAYS = 7
+
+
+def get_connection(db_path=None):
+    """Get a DuckDB connection, creating the cache table if needed."""
+    path = db_path or _DEFAULT_DB_PATH
+    conn = duckdb.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS link_cache (
+            page_title TEXT PRIMARY KEY,
+            links JSON NOT NULL,
+            fetched_at TIMESTAMP NOT NULL
+        )
+    """)
+    return conn
+
+
+def get_cached_links(conn, title, ttl_days=_DEFAULT_TTL_DAYS):
+    """
+    Look up cached links for a page title.
+
+    Returns a list of link titles if cached and not expired, else None.
+    """
+    cutoff = datetime.now() - timedelta(days=ttl_days)
+    result = conn.execute(
+        "SELECT links FROM link_cache WHERE page_title = ? AND fetched_at > ?",
+        [title, cutoff],
+    ).fetchone()
+    if result is None:
+        return None
+    return json.loads(result[0])
+
+
+def set_cached_links(conn, title, links):
+    """Store links for a page title in the cache."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO link_cache (page_title, links, fetched_at)
+        VALUES (?, ?, ?)
+        """,
+        [title, json.dumps(links), datetime.now()],
+    )
+
+
+def get_cache_stats(conn):
+    """Return cache statistics."""
+    row = conn.execute("SELECT COUNT(*) FROM link_cache").fetchone()
+    return {"total_pages": row[0]}

--- a/wikiviz/core.py
+++ b/wikiviz/core.py
@@ -143,13 +143,30 @@ def get_links(page):
     return sorted(page.links.keys())
 
 
+def _get_links_cached(title, session=None, cache_conn=None):
+    """Fetch content links, using DuckDB cache if available."""
+    if cache_conn is not None:
+        from wikiviz.cache import get_cached_links, set_cached_links
+        cached = get_cached_links(cache_conn, title)
+        if cached is not None:
+            return cached
+
+    links = clean_links(get_content_links(title, session=session))
+
+    if cache_conn is not None:
+        set_cached_links(cache_conn, title, links)
+
+    return links
+
+
 def find_shortest_path(page_a_name, page_b_name, wiki=None, on_progress=None,
-                       session=None):
+                       session=None, cache_conn=None):
     """
     Find the shortest path between two Wikipedia pages.
 
     Uses MediaWiki API with section-aware link fetching to skip
     non-content sections (References, Bibliography, See also, etc.).
+    Optionally caches results in DuckDB for faster repeated searches.
 
     Args:
         page_a_name: Title of the first Wikipedia page.
@@ -157,6 +174,7 @@ def find_shortest_path(page_a_name, page_b_name, wiki=None, on_progress=None,
         wiki: Optional wikipediaapi.Wikipedia instance (for testing with mocks).
         on_progress: Optional callback(pages_explored, current_title) for UI updates.
         session: Optional requests.Session for connection reuse.
+        cache_conn: Optional DuckDB connection for link caching.
 
     Returns:
         Tuple of (path, graph) where path is a list of page titles forming
@@ -177,8 +195,8 @@ def find_shortest_path(page_a_name, page_b_name, wiki=None, on_progress=None,
     if not page_exists(page_b_name, session=s):
         raise ValueError(f"Page not found: {page_b_name}")
 
-    links_a = clean_links(get_content_links(page_a_name, session=s))
-    links_b = clean_links(get_content_links(page_b_name, session=s))
+    links_a = _get_links_cached(page_a_name, session=s, cache_conn=cache_conn)
+    links_b = _get_links_cached(page_b_name, session=s, cache_conn=cache_conn)
 
     graph = {
         page_a_name: links_a,
@@ -191,7 +209,7 @@ def find_shortest_path(page_a_name, page_b_name, wiki=None, on_progress=None,
         if on_progress:
             on_progress(i + 1, t)
 
-        page_links = clean_links(get_content_links(t, session=s))
+        page_links = _get_links_cached(t, session=s, cache_conn=cache_conn)
 
         graph[t] = copy.deepcopy(page_links)
 


### PR DESCRIPTION
- Cache explored page links in DuckDB to skip API calls on repeat searches
- 7-day TTL with automatic expiration
- Sidebar shows cached page count
- Cache persists across Streamlit sessions via wikiviz_cache.duckdb file
- In-memory DuckDB used for tests (no disk artifacts)
- Add .duckdb files to .gitignore